### PR TITLE
feat(orgs): adding barebones for org page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -28,6 +28,10 @@ const Layout: React.FunctionComponent<Props> = ({
         <Link href="/users">
           <a>Users List</a>
         </Link>{' '}
+        |{' '}
+        <Link href="/orgs">
+          <a>Orgs List</a>
+        </Link>{' '}
         | <a href="/api/users">Users API</a>
       </nav>
     </header>

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -12,4 +12,5 @@ export type User = {
 export type Organization = {
   id: number;
   name: string;
+  hasBlueberries: boolean;
 };

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -12,5 +12,4 @@ export type User = {
 export type Organization = {
   id: number;
   name: string;
-  hasBlueberries: boolean;
 };

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -8,3 +8,9 @@ export type User = {
   id: number;
   name: string;
 };
+
+export type Organization = {
+  id: number;
+  name: string;
+  hasBlueberries: boolean;
+};

--- a/pages/orgs/[id].tsx
+++ b/pages/orgs/[id].tsx
@@ -1,0 +1,63 @@
+import { GetStaticProps, GetStaticPaths } from 'next';
+import { Organization } from 'interfaces';
+import { sampleOrgData } from 'utils/sample-data';
+import Layout from 'components/Layout';
+import ListDetail from 'components/ListDetail';
+
+type Props = {
+  item?: Organization;
+  errors?: string;
+};
+
+const StaticPropsDetail: React.FunctionComponent<Props> = ({
+  item,
+  errors,
+}) => {
+  if (errors) {
+    return (
+      <Layout title="Error | Next.js + TypeScript Example">
+        <p>
+          <span style={{ color: 'red' }}>Error:</span> {errors}
+        </p>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout
+      title={`${
+        item ? item.name : 'Organization Detail'
+      } | Next.js + TypeScript Example`}
+    >
+      {item && <ListDetail item={item} />}
+    </Layout>
+  );
+};
+
+export default StaticPropsDetail;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Get the paths we want to pre-render based on users
+  const paths = sampleOrgData.map((user) => ({
+    params: { id: user.id.toString() },
+  }));
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } means other routes should 404.
+  return { paths, fallback: false };
+};
+
+// This function gets called at build time on server-side.
+// It won't be called on client-side, so you can even do
+// direct database queries.
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  try {
+    const id = params?.id;
+    const item = sampleOrgData.find((data) => data.id === Number(id));
+    // By returning { props: item }, the StaticPropsDetail component
+    // will receive `item` as a prop at build time
+    return { props: { item } };
+  } catch (err) {
+    return { props: { errors: err.message } };
+  }
+};

--- a/pages/orgs/index.tsx
+++ b/pages/orgs/index.tsx
@@ -1,0 +1,38 @@
+import { GetStaticProps } from 'next';
+import Link from 'next/link';
+
+import { Organization } from 'interfaces';
+import { sampleOrgData } from 'utils/sample-data';
+import Layout from 'components/Layout';
+import List from 'components/List';
+
+type Props = {
+  items: Organization[];
+};
+
+const WithStaticProps: React.FunctionComponent<Props> = ({ items }) => (
+  <Layout title="Organization List | Next.js + TypeScript Example">
+    <h1>Orgs List</h1>
+    <p>
+      RANDOM TEXT RANDOM TEXT RANDOM TEXT RANDOM TEXT RANDOM TEXT RANDOM TEXT
+      RANDOM TEXT RANDOM TEXT
+    </p>
+    <p>You are currently on: /orgs</p>
+    <List items={items} />
+    <p>
+      <Link href="/">
+        <a>Go home</a>
+      </Link>
+    </p>
+  </Layout>
+);
+
+export const getStaticProps: GetStaticProps = async () => {
+  // Example for including static props in a Next.js function component page.
+  // Don't forget to include the respective types for any props passed into
+  // the component.
+  const items: Organization[] = sampleOrgData;
+  return { props: { items } };
+};
+
+export default WithStaticProps;

--- a/pages/orgs/index.tsx
+++ b/pages/orgs/index.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { Organization } from 'interfaces';
 import { sampleOrgData } from 'utils/sample-data';
 import Layout from 'components/Layout';
-import List from 'components/List';
 
 type Props = {
   items: Organization[];
@@ -18,8 +17,13 @@ const WithStaticProps: React.FunctionComponent<Props> = ({ items }) => (
       RANDOM TEXT RANDOM TEXT
     </p>
     <p>You are currently on: /orgs</p>
-    {/* This is broken because List is implemented with 'user' URL */}
-    <List items={items} />
+    {items.map((item) => (
+      <Link href="/orgs/[id]" as={`/orgs/${item.id}`}>
+        <a>
+          {item.id}: {item.name}
+        </a>
+      </Link>
+    ))}
     <p>
       <Link href="/">
         <a>Go home</a>

--- a/pages/orgs/index.tsx
+++ b/pages/orgs/index.tsx
@@ -18,6 +18,7 @@ const WithStaticProps: React.FunctionComponent<Props> = ({ items }) => (
       RANDOM TEXT RANDOM TEXT
     </p>
     <p>You are currently on: /orgs</p>
+    {/* This is broken because List is implemented with 'user' URL */}
     <List items={items} />
     <p>
       <Link href="/">

--- a/pages/orgs/index.tsx
+++ b/pages/orgs/index.tsx
@@ -18,7 +18,6 @@ const WithStaticProps: React.FunctionComponent<Props> = ({ items }) => (
       RANDOM TEXT RANDOM TEXT
     </p>
     <p>You are currently on: /orgs</p>
-    {/* This is broken because List is implemented with 'user' URL */}
     <List items={items} />
     <p>
       <Link href="/">

--- a/prisma/.env
+++ b/prisma/.env
@@ -1,0 +1,7 @@
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="postgresql://postgres@localhost:5432/nbjc_development?schema=public"

--- a/prisma/.env
+++ b/prisma/.env
@@ -1,7 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-DATABASE_URL="postgresql://postgres@localhost:5432/nbjc_development?schema=public"

--- a/utils/sample-data.ts
+++ b/utils/sample-data.ts
@@ -10,8 +10,8 @@ export const sampleUserData: User[] = [
 ];
 
 export const sampleOrgData: Organization[] = [
-  { id: 1, name: 'Blueprint', hasBlueberries: true },
-  { id: 2, name: 'Redprint', hasBlueberries: false },
-  { id: 3, name: 'Greenprint', hasBlueberries: true },
-  { id: 420, name: 'Yellowprint', hasBlueberries: false },
+  { id: 1, name: 'Blueprint' },
+  { id: 2, name: 'Redprint' },
+  { id: 3, name: 'Greenprint' },
+  { id: 420, name: 'Yellowprint' },
 ];

--- a/utils/sample-data.ts
+++ b/utils/sample-data.ts
@@ -1,4 +1,4 @@
-import { User } from 'interfaces';
+import { Organization, User } from 'interfaces';
 
 /** Dummy user data. */
 // eslint-disable-next-line import/prefer-default-export
@@ -7,4 +7,11 @@ export const sampleUserData: User[] = [
   { id: 102, name: 'Bob' },
   { id: 103, name: 'Caroline' },
   { id: 104, name: 'Dave' },
+];
+
+export const sampleOrgData: Organization[] = [
+  { id: 1, name: 'Blueprint', hasBlueberries: true },
+  { id: 2, name: 'Redprint', hasBlueberries: false },
+  { id: 3, name: 'Greenprint', hasBlueberries: true },
+  { id: 420, name: 'Yellowprint', hasBlueberries: false },
 ];

--- a/utils/sample-data.ts
+++ b/utils/sample-data.ts
@@ -10,8 +10,8 @@ export const sampleUserData: User[] = [
 ];
 
 export const sampleOrgData: Organization[] = [
-  { id: 1, name: 'Blueprint' },
-  { id: 2, name: 'Redprint' },
-  { id: 3, name: 'Greenprint' },
-  { id: 420, name: 'Yellowprint' },
+  { id: 1, name: 'Blueprint', hasBlueberries: true },
+  { id: 2, name: 'Redprint', hasBlueberries: false },
+  { id: 3, name: 'Greenprint', hasBlueberries: true },
+  { id: 420, name: 'Yellowprint', hasBlueberries: false },
 ];


### PR DESCRIPTION
# Adding barebones to org page

Added `org` directory of `[id].tsx` and `index.tsx` so that we can have routing for different org pages in the codebase.

## Related PRs

_Optional - any related PRs you're waiting on, or PRs that will conflict, etc_

## Migrations

_Optional - if you added anything to the database through migration(s)_

## Screenshots

_Required for visual changes_

CC: @kwfk
