### PR TITLE
Add created_at and updated_at to Organizations table

### DIFF
--- a/migrations/20201005031531-create-organizations.ts
+++ b/migrations/20201005031531-create-organizations.ts
@@ -8,18 +8,22 @@ export async function up(
   db: Base,
   callback: Base.CallbackFunction
 ): Promise<void> {
-  const createTable = promisify(db.createTable.bind(db));
-  try {
-    await createTable('organizations', {
-      id: { type: 'int', primaryKey: true, autoIncrement: true },
-      name: { type: 'string', notNull: true },
-      long: 'decimal',
-      lat: 'decimal',
-      type: 'string',
-    });
-  } catch (err) {
-    callback(err, null);
-  }
+  db.runSql(
+    `
+    CREATE TABLE organizations
+      (
+        id         SERIAL,
+        name       VARCHAR(255) NOT NULL,
+        long       DECIMAL,
+        lat        DECIMAL,
+        type       VARCHAR(255),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id)
+      );
+  `,
+    callback
+  );
 }
 
 /**


### PR DESCRIPTION
Updated create-organizations migration to add created_at and updated_at fields to the Organizations table

## Migrations

Edited previous migration. Will require a **reset** of database
