### PR TITLE
Change validation of org app API

### DIFF
--- a/interfaces/organizationApplication.ts
+++ b/interfaces/organizationApplication.ts
@@ -9,9 +9,7 @@ import {
 } from '@prisma/client';
 
 const schema = Joi.object({
-  applicationStatus: Joi.string()
-    .valid(...Object.values(ApplicationStatus))
-    .when('$strict', { is: true, then: Joi.required() }),
+  applicationStatus: Joi.string().valid(...Object.values(ApplicationStatus)),
   organizationName: Joi.string().when('$strict', {
     is: true,
     then: Joi.required(),

--- a/pages/api/organization-applications/index.ts
+++ b/pages/api/organization-applications/index.ts
@@ -9,7 +9,9 @@ const prisma = new PrismaClient();
 export const createOrganizationApp = async (
   body: OrganizationApplication
 ): Promise<OrganizationApplication | null> => {
-  const { error, value } = OrganizationApplicationSchema.validate(body);
+  const { error, value } = OrganizationApplicationSchema.validate(body, {
+    context: { strict: true },
+  });
   if (error) {
     throw error;
   }


### PR DESCRIPTION
- Make applicationStatus not required when strict because it has a default value.
- Turn on strict context in org app api

## Related PRs

#17 