### PR TITLE
gabe/Results Page Filtering Front End

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,7 +6,11 @@ import {
   LinearProgress,
   Menu,
   MenuItem,
+  TextField,
+  InputAdornment,
+  IconButton,
 } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
 import { useRouter } from 'next/router';
 import useSession from 'utils/useSession';
 import { signOut } from 'next-auth/client';
@@ -15,17 +19,53 @@ import styles from '../styles/Layout.module.css';
 
 type Props = {
   title?: string;
+  page?: boolean;
+  handleClickSearch?: () => void;
+  searchFilters?: string;
+  handleSearchChange?: React.ChangeEventHandler<HTMLInputElement>;
 };
 
 const Layout: React.FunctionComponent<Props> = ({
   children,
   title = 'NBJC',
+  handleClickSearch,
+  searchFilters,
+  handleSearchChange,
 }) => {
   const router = useRouter();
   const [session, sessionLoading] = useSession();
   const [userMenuAnchor, setUserMenuAnchor] = useState<HTMLElement | null>(
     null
   );
+
+  let searchBar = null;
+  if (handleClickSearch) {
+    searchBar = (
+      <div className={styles.searchbar}>
+        <TextField
+          placeholder="Explore Organizations"
+          fullWidth
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <IconButton onClick={handleClickSearch}>
+                  <SearchIcon />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          variant="outlined"
+          value={searchFilters}
+          onChange={handleSearchChange}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleClickSearch();
+            }
+          }}
+        />
+      </div>
+    );
+  }
 
   if (sessionLoading) return <LinearProgress />;
   return (
@@ -42,6 +82,7 @@ const Layout: React.FunctionComponent<Props> = ({
               <h1>NBJC</h1>
             </a>
           </Link>
+          {searchBar}
           <div className={styles.nav}>
             {session &&
             (session.user.role === 'moderator' ||

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,6 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import { useFormik } from 'formik';
 import Layout from 'components/Layout';
 import { homepageFields } from 'interfaces';
-import Link from 'next/link';
 import Router from 'next/router';
 import {
   AgeDemographicLabels,

--- a/pages/results.tsx
+++ b/pages/results.tsx
@@ -1,13 +1,14 @@
 import { GetServerSideProps } from 'next';
-<<<<<<< HEAD
 import {
-  PrismaClient,
   LgbtqDemographic,
   RaceDemographic,
   AgeDemographic,
 } from '@prisma/client';
-=======
->>>>>>> feat: front end filters
+import {
+  AgeDemographicLabels,
+  LgbtqDemographicLabels,
+  RaceDemographicLabels,
+} from 'utils/typesLinker';
 import prisma from 'utils/prisma';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
@@ -23,31 +24,18 @@ import {
   CardContent,
   Typography,
   CardActionArea,
-<<<<<<< HEAD
+  Button,
+  ButtonProps,
 } from '@material-ui/core';
-import {
-  AgeDemographicLabels,
-  LgbtqDemographicLabels,
-  RaceDemographicLabels,
-} from 'utils/typesLinker';
-
 import SearchIcon from '@material-ui/icons/Search';
 import Layout from 'components/Layout';
+import { useState } from 'react';
 import styles from '../styles/Results.module.css';
-=======
-  Chip,
-  Button
-} from '@material-ui/core';
-import SearchIcon from '@material-ui/icons/Search';
-import Layout from 'components/Layout';
-import styles from '../styles/Home.module.css';
->>>>>>> feat: front end filters
 
 const Map = dynamic(() => import('../components/Map'), {
   ssr: false,
 });
 
-<<<<<<< HEAD
 type ResultsProps = {
   orgs: PublicOrganization[];
 };
@@ -55,49 +43,25 @@ type ResultsProps = {
 // const prisma = new PrismaClient();
 
 const Results: React.FC<ResultsProps> = ({ orgs }) => {
-=======
-type HomeProps = {
-  orgs: PublicOrganization[];
-};
-
-// using lists for now, but maybe replace with enums?
-const demographicTypes = [
-  'LGBTQ+',
-  'SGL',
-  'Transgender',
-  'Asexual/Aromantic',
-  'Other',
-];
-
-const backgroundTypes = ['Grassroots/Local', 'Statewide', 'National', 'Other'];
-
-const audienceTypes = [
-  'POC (All)',
-  'Black',
-  'Asian',
-  'Pacific Islander',
-  'Latinx',
-  'Native/Indigeneous',
-  'Other',
-];
-
-const Home: React.FC<HomeProps> = ({ orgs }) => {
->>>>>>> feat: front end filters
   const router = useRouter();
+
+  // TO-DO optimize theme/color changes with Select, MenuItem, & Button components
+  const demographicTypes = Object.keys(
+    LgbtqDemographicLabels
+  ) as LgbtqDemographic[];
+  const backgroundTypes = Object.keys(
+    RaceDemographicLabels
+  ) as RaceDemographic[];
+  const audienceTypes = Object.keys(AgeDemographicLabels) as AgeDemographic[];
 
   // This is to verify whether or not the current user has a proper session configured to see the page.
   // Will be implemented in the next PR.
   // const [session, loading] = useSession();
 
-<<<<<<< HEAD
-=======
-  const [demographicFilters, setDemographicFilters] = React.useState<string[]>(
-    []
-  );
-  const [backgroundFilters, setBackgroundFilters] = React.useState<string[]>(
-    []
-  );
-  const [audienceFilters, setAudienceFilters] = React.useState<string[]>([]);
+  const [demographicFilters, setDemographicFilters] = useState<string[]>([]);
+  const [backgroundFilters, setBackgroundFilters] = useState<string[]>([]);
+
+  const [audienceFilters, setAudienceFilters] = useState<string[]>([]);
 
   const handleDemographicChange = (
     event: React.ChangeEvent<{ value: unknown }>
@@ -109,7 +73,6 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
     event: React.ChangeEvent<{ value: unknown }>
   ): void => {
     setBackgroundFilters(event.target.value as string[]);
-    console.log(event.target.value as string[]);
   };
 
   const handleAudienceChange = (
@@ -118,9 +81,11 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
     setAudienceFilters(event.target.value as string[]);
   };
 
-  const outlinedButton = (props) => <Button variant="outlined" disableRipple {...props}/>
+  // TO-DO fix return type here
+  const outlinedButton = (props: ButtonProps): any => (
+    <Button variant="outlined" disableRipple {...props} />
+  );
 
->>>>>>> feat: front end filters
   return (
     <Layout>
       <div className={styles.pageFlex}>
@@ -141,50 +106,28 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
         <div className={styles.pageContent}>
           <div className={styles.leftCol}>
             <div className={styles.filters}>
-<<<<<<< HEAD
-              <FormControl className={styles.filter} variant="outlined">
-                <InputLabel>Keyword</InputLabel>
-                <Select label="Keyword">
-                  <MenuItem value="">
-                    <em>None</em>
-                  </MenuItem>
-                  <MenuItem value={1}>One</MenuItem>
-                  <MenuItem value={2}>Two</MenuItem>
-                  <MenuItem value={3}>Three</MenuItem>
-                </Select>
-              </FormControl>
-              <FormControl className={styles.filter} variant="outlined">
-                <InputLabel>Keyword</InputLabel>
-                <Select label="Keyword">
-                  <MenuItem value="">
-                    <em>None</em>
-                  </MenuItem>
-                  <MenuItem value={1}>One</MenuItem>
-                  <MenuItem value={2}>Two</MenuItem>
-                  <MenuItem value={3}>Three</MenuItem>
-                </Select>
-              </FormControl>
-              <FormControl className={styles.filter} variant="outlined">
-                <InputLabel>More</InputLabel>
-                <Select label="More">
-                  <MenuItem value="">
-                    <em>None</em>
-                  </MenuItem>
-                  <MenuItem value={1}>One</MenuItem>
-                  <MenuItem value={2}>Two</MenuItem>
-                  <MenuItem value={3}>Three</MenuItem>
-=======
-              <FormControl focused={Boolean(demographicFilters.length)} className={styles.filter} variant="outlined">
-                <InputLabel shrink={false} classes={{ root: styles.filterLabel}}>
-                  {!Boolean(demographicFilters.length) && "Identities"}
+              <FormControl
+                focused={Boolean(demographicFilters.length)}
+                className={styles.filter}
+                variant="outlined"
+              >
+                <InputLabel
+                  shrink={false}
+                  classes={{ root: styles.filterLabel }}
+                >
+                  {!demographicFilters.length && 'Identities'}
                 </InputLabel>
                 <Select
                   native={false}
-                  className={styles.filterDropDown}
+                  className={
+                    demographicFilters.length > 0
+                      ? styles.filterDropDownActive
+                      : styles.filterDropDown
+                  }
                   multiple
                   value={demographicFilters}
                   onChange={handleDemographicChange}
-                  renderValue={(value) => (
+                  renderValue={() => (
                     <InputLabel classes={{ root: styles.selectedLabel }}>
                       Identities
                     </InputLabel>
@@ -198,33 +141,46 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
                     getContentAnchorEl: null,
                   }}
                 >
-                  {demographicTypes.map((filterOption: string) => (
+                  {demographicTypes.map((filterOption: LgbtqDemographic) => (
                     <MenuItem
                       classes={{
                         selected: styles.selectedFilter,
                         root: styles.filterOption,
                       }}
-                      style={{ backgroundColor: demographicFilters.includes(filterOption) ? '#F8F4FF' :  'transparent'}}
+                      style={{
+                        backgroundColor: demographicFilters.includes(
+                          LgbtqDemographicLabels[filterOption]
+                        )
+                          ? '#F8F4FF'
+                          : 'transparent',
+                      }}
                       component={outlinedButton}
                       disableRipple
-                      value={filterOption}
-                      key={filterOption}
+                      value={LgbtqDemographicLabels[filterOption]}
                     >
-                      {filterOption}
+                      {LgbtqDemographicLabels[filterOption]}
                     </MenuItem>
                   ))}
                 </Select>
               </FormControl>
-              <FormControl focused={Boolean(backgroundFilters.length)} className={styles.filter} variant="outlined">
+              <FormControl
+                focused={Boolean(backgroundFilters.length)}
+                className={styles.filter}
+                variant="outlined"
+              >
                 <InputLabel shrink={false} className={styles.filterLabel}>
-                  {!Boolean(backgroundFilters.length) && "Background"}
+                  {!backgroundFilters.length && 'Background'}
                 </InputLabel>
                 <Select
-                  className={styles.filterDropDown}
+                  className={
+                    backgroundFilters.length > 0
+                      ? styles.filterDropDownActive
+                      : styles.filterDropDown
+                  }
                   multiple
                   value={backgroundFilters}
                   onChange={handleBackgroundChange}
-                  renderValue={(value) => (
+                  renderValue={() => (
                     <InputLabel classes={{ root: styles.selectedLabel }}>
                       Background
                     </InputLabel>
@@ -238,7 +194,7 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
                     getContentAnchorEl: null,
                   }}
                 >
-                  {backgroundTypes.map((filterOption: string) => (
+                  {backgroundTypes.map((filterOption: RaceDemographic) => (
                     <MenuItem
                       classes={{
                         selected: styles.selectedFilter,
@@ -246,26 +202,39 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
                       }}
                       component={outlinedButton}
                       className={styles.filterOption}
-                      style={{ backgroundColor: backgroundFilters.includes(filterOption) ? '#F8F4FF' :  'transparent'}}
+                      style={{
+                        backgroundColor: backgroundFilters.includes(
+                          RaceDemographicLabels[filterOption]
+                        )
+                          ? '#F8F4FF'
+                          : 'transparent',
+                      }}
                       disableRipple
-                      value={filterOption}
-                      key={filterOption}
+                      value={RaceDemographicLabels[filterOption]}
                     >
-                      {filterOption}
+                      {RaceDemographicLabels[filterOption]}
                     </MenuItem>
                   ))}
                 </Select>
               </FormControl>
-              <FormControl focused={Boolean(audienceFilters.length)} className={styles.filter} variant="outlined">
+              <FormControl
+                focused={Boolean(audienceFilters.length)}
+                className={styles.filter}
+                variant="outlined"
+              >
                 <InputLabel shrink={false} className={styles.filterLabel}>
-                {!Boolean(audienceFilters.length) && "Audience"}
+                  {!audienceFilters.length && 'Audience'}
                 </InputLabel>
                 <Select
-                  className={styles.filterDropDown}
+                  className={
+                    audienceFilters.length > 0
+                      ? styles.filterDropDownActive
+                      : styles.filterDropDown
+                  }
                   multiple
                   value={audienceFilters}
                   onChange={handleAudienceChange}
-                  renderValue={(value) => (
+                  renderValue={() => (
                     <InputLabel classes={{ root: styles.selectedLabel }}>
                       Audience
                     </InputLabel>
@@ -279,7 +248,7 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
                     getContentAnchorEl: null,
                   }}
                 >
-                  {audienceTypes.map((filterOption: string) => (
+                  {audienceTypes.map((filterOption: AgeDemographic) => (
                     <MenuItem
                       classes={{
                         selected: styles.selectedFilter,
@@ -287,24 +256,24 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
                       }}
                       component={outlinedButton}
                       disableRipple
-                      style={{ backgroundColor: audienceFilters.includes(filterOption) ? '#F8F4FF' :  'transparent'}}
-                      value={filterOption}
-                      key={filterOption}
+                      style={{
+                        backgroundColor: audienceFilters.includes(
+                          AgeDemographicLabels[filterOption]
+                        )
+                          ? '#F8F4FF'
+                          : 'transparent',
+                      }}
+                      value={AgeDemographicLabels[filterOption]}
                     >
-                      {filterOption}
+                      {AgeDemographicLabels[filterOption]}
                     </MenuItem>
                   ))}
->>>>>>> feat: front end filters
                 </Select>
               </FormControl>
             </div>
 
             <div className={styles.cards}>
-<<<<<<< HEAD
               {orgs && orgs.length !== 0 ? (
-=======
-              {orgs.length !== 0 ? (
->>>>>>> feat: front end filters
                 orgs.map((org) => (
                   <Card className={styles.card} key={org.id}>
                     <CardActionArea
@@ -336,55 +305,7 @@ const Home: React.FC<HomeProps> = ({ orgs }) => {
   );
 };
 
-<<<<<<< HEAD
 export default Results;
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  try {
-    // Only add filters if they are listed, otherwise use all filters
-    const orientationBody = context.query.orientation
-      ? context.query.orientation
-      : Object.keys(LgbtqDemographicLabels);
-    const ethnicityBody = context.query.ethnicity
-      ? context.query.ethnicity
-      : Object.keys(RaceDemographicLabels);
-    const agesBody = context.query.ages
-      ? context.query.ages
-      : Object.keys(AgeDemographicLabels);
-    const orgs = await prisma.organization.findMany({
-      where: {
-        name: {
-          contains: context.query?.orgName as string,
-          mode: 'insensitive',
-        },
-        lgbtqDemographic: {
-          hasSome: orientationBody as LgbtqDemographic[],
-        },
-        raceDemographic: {
-          hasSome: ethnicityBody as RaceDemographic[],
-        },
-        ageDemographic: {
-          hasSome: agesBody as AgeDemographic[],
-        },
-      },
-    });
-    const propOrgs = JSON.parse(JSON.stringify(orgs)) as PublicOrganization[];
-    return {
-      props: {
-        orgs: propOrgs,
-      },
-    };
-  } catch (err) {
-    // Probably do a better error state, toast? Not just redirect and not indicate anything.
-    console.log(err);
-    return {
-      redirect: {
-        permanent: false,
-        destination: '/',
-      },
-    };
-=======
-export default Home;
 
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
@@ -410,6 +331,5 @@ export const getServerSideProps: GetServerSideProps = async () => {
     };
   } catch (err) {
     return { props: { errors: err.message } };
->>>>>>> feat: front end filters
   }
 };

--- a/pages/results.tsx
+++ b/pages/results.tsx
@@ -10,9 +10,9 @@ import {
   RaceDemographicLabels,
 } from 'utils/typesLinker';
 import prisma from 'utils/prisma';
-import { useRouter } from 'next/router';
+import Router, { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
-import Router from 'next/router';
+
 import { PublicOrganization } from 'interfaces/organization';
 import {
   TextField,
@@ -28,7 +28,6 @@ import {
   Button,
   ButtonProps,
 } from '@material-ui/core';
-import SearchIcon from '@material-ui/icons/Search';
 import Layout from 'components/Layout';
 import { useState } from 'react';
 import styles from '../styles/Results.module.css';
@@ -39,11 +38,12 @@ const Map = dynamic(() => import('../components/Map'), {
 
 type ResultsProps = {
   orgs: PublicOrganization[];
+  searchValProp: string;
 };
 
 // const prisma = new PrismaClient();
 
-const Results: React.FC<ResultsProps> = ({ orgs }) => {
+const Results: React.FC<ResultsProps> = ({ orgs, searchValProp }) => {
   const router = useRouter();
 
   // TO-DO optimize theme/color changes with Select, MenuItem, & Button components
@@ -59,6 +59,7 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
   // Will be implemented in the next PR.
   // const [session, loading] = useSession();
 
+  const [searchVal, setSearchVal] = useState(searchValProp);
   const [demographicFilters, setDemographicFilters] = useState<string[]>([]);
   const [backgroundFilters, setBackgroundFilters] = useState<string[]>([]);
   const [audienceFilters, setAudienceFilters] = useState<string[]>([]);
@@ -86,11 +87,11 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
     <Button variant="outlined" disableRipple {...props} />
   );
 
-  const handleSearch = () => {
+  const handleSearch = (): void => {
     Router.push({
       pathname: 'results',
       query: {
-        // orgName: values.orgName,
+        orgName: searchVal,
         ages: audienceFilters,
         ethnicity: backgroundFilters,
         orientation: demographicFilters,
@@ -118,22 +119,12 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
   };
 
   return (
-    <Layout>
+    <Layout
+      handleClickSearch={() => handleSearch()}
+      searchFilters={searchVal}
+      handleSearchChange={(event) => setSearchVal(event.target.value)}
+    >
       <div className={styles.pageFlex}>
-        <TextField
-          id="outlined-size-small"
-          placeholder="Explore Organizations"
-          fullWidth
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon />
-              </InputAdornment>
-            ),
-          }}
-          variant="outlined"
-        />
-
         <div className={styles.pageContent}>
           <div className={styles.leftCol}>
             <div className={styles.filters}>
@@ -301,7 +292,15 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
                   ))}
                 </Select>
               </FormControl>
-              <button onClick={handleSearch}>Search</button>
+              <Button
+                variant="contained"
+                color="primary"
+                className={styles.applyButton}
+                onClick={handleSearch}
+                disableElevation
+              >
+                Apply
+              </Button>
             </div>
 
             <div className={styles.cards}>
@@ -373,6 +372,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return {
       props: {
         orgs: propOrgs,
+        searchValProp: context.query?.orgName,
       },
     };
   } catch (err) {

--- a/pages/results.tsx
+++ b/pages/results.tsx
@@ -1,10 +1,13 @@
 import { GetServerSideProps } from 'next';
+<<<<<<< HEAD
 import {
   PrismaClient,
   LgbtqDemographic,
   RaceDemographic,
   AgeDemographic,
 } from '@prisma/client';
+=======
+>>>>>>> feat: front end filters
 import prisma from 'utils/prisma';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
@@ -20,6 +23,7 @@ import {
   CardContent,
   Typography,
   CardActionArea,
+<<<<<<< HEAD
 } from '@material-ui/core';
 import {
   AgeDemographicLabels,
@@ -30,11 +34,20 @@ import {
 import SearchIcon from '@material-ui/icons/Search';
 import Layout from 'components/Layout';
 import styles from '../styles/Results.module.css';
+=======
+  Chip,
+  Button
+} from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+import Layout from 'components/Layout';
+import styles from '../styles/Home.module.css';
+>>>>>>> feat: front end filters
 
 const Map = dynamic(() => import('../components/Map'), {
   ssr: false,
 });
 
+<<<<<<< HEAD
 type ResultsProps = {
   orgs: PublicOrganization[];
 };
@@ -42,12 +55,72 @@ type ResultsProps = {
 // const prisma = new PrismaClient();
 
 const Results: React.FC<ResultsProps> = ({ orgs }) => {
+=======
+type HomeProps = {
+  orgs: PublicOrganization[];
+};
+
+// using lists for now, but maybe replace with enums?
+const demographicTypes = [
+  'LGBTQ+',
+  'SGL',
+  'Transgender',
+  'Asexual/Aromantic',
+  'Other',
+];
+
+const backgroundTypes = ['Grassroots/Local', 'Statewide', 'National', 'Other'];
+
+const audienceTypes = [
+  'POC (All)',
+  'Black',
+  'Asian',
+  'Pacific Islander',
+  'Latinx',
+  'Native/Indigeneous',
+  'Other',
+];
+
+const Home: React.FC<HomeProps> = ({ orgs }) => {
+>>>>>>> feat: front end filters
   const router = useRouter();
 
   // This is to verify whether or not the current user has a proper session configured to see the page.
   // Will be implemented in the next PR.
   // const [session, loading] = useSession();
 
+<<<<<<< HEAD
+=======
+  const [demographicFilters, setDemographicFilters] = React.useState<string[]>(
+    []
+  );
+  const [backgroundFilters, setBackgroundFilters] = React.useState<string[]>(
+    []
+  );
+  const [audienceFilters, setAudienceFilters] = React.useState<string[]>([]);
+
+  const handleDemographicChange = (
+    event: React.ChangeEvent<{ value: unknown }>
+  ): void => {
+    setDemographicFilters(event.target.value as string[]);
+  };
+
+  const handleBackgroundChange = (
+    event: React.ChangeEvent<{ value: unknown }>
+  ): void => {
+    setBackgroundFilters(event.target.value as string[]);
+    console.log(event.target.value as string[]);
+  };
+
+  const handleAudienceChange = (
+    event: React.ChangeEvent<{ value: unknown }>
+  ): void => {
+    setAudienceFilters(event.target.value as string[]);
+  };
+
+  const outlinedButton = (props) => <Button variant="outlined" disableRipple {...props}/>
+
+>>>>>>> feat: front end filters
   return (
     <Layout>
       <div className={styles.pageFlex}>
@@ -68,6 +141,7 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
         <div className={styles.pageContent}>
           <div className={styles.leftCol}>
             <div className={styles.filters}>
+<<<<<<< HEAD
               <FormControl className={styles.filter} variant="outlined">
                 <InputLabel>Keyword</InputLabel>
                 <Select label="Keyword">
@@ -99,12 +173,138 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
                   <MenuItem value={1}>One</MenuItem>
                   <MenuItem value={2}>Two</MenuItem>
                   <MenuItem value={3}>Three</MenuItem>
+=======
+              <FormControl focused={Boolean(demographicFilters.length)} className={styles.filter} variant="outlined">
+                <InputLabel shrink={false} classes={{ root: styles.filterLabel}}>
+                  {!Boolean(demographicFilters.length) && "Identities"}
+                </InputLabel>
+                <Select
+                  native={false}
+                  className={styles.filterDropDown}
+                  multiple
+                  value={demographicFilters}
+                  onChange={handleDemographicChange}
+                  renderValue={(value) => (
+                    <InputLabel classes={{ root: styles.selectedLabel }}>
+                      Identities
+                    </InputLabel>
+                  )}
+                  MenuProps={{
+                    variant: 'menu',
+                    anchorOrigin: {
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    },
+                    getContentAnchorEl: null,
+                  }}
+                >
+                  {demographicTypes.map((filterOption: string) => (
+                    <MenuItem
+                      classes={{
+                        selected: styles.selectedFilter,
+                        root: styles.filterOption,
+                      }}
+                      style={{ backgroundColor: demographicFilters.includes(filterOption) ? '#F8F4FF' :  'transparent'}}
+                      component={outlinedButton}
+                      disableRipple
+                      value={filterOption}
+                      key={filterOption}
+                    >
+                      {filterOption}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl focused={Boolean(backgroundFilters.length)} className={styles.filter} variant="outlined">
+                <InputLabel shrink={false} className={styles.filterLabel}>
+                  {!Boolean(backgroundFilters.length) && "Background"}
+                </InputLabel>
+                <Select
+                  className={styles.filterDropDown}
+                  multiple
+                  value={backgroundFilters}
+                  onChange={handleBackgroundChange}
+                  renderValue={(value) => (
+                    <InputLabel classes={{ root: styles.selectedLabel }}>
+                      Background
+                    </InputLabel>
+                  )}
+                  MenuProps={{
+                    variant: 'menu',
+                    anchorOrigin: {
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    },
+                    getContentAnchorEl: null,
+                  }}
+                >
+                  {backgroundTypes.map((filterOption: string) => (
+                    <MenuItem
+                      classes={{
+                        selected: styles.selectedFilter,
+                        root: styles.filterOption,
+                      }}
+                      component={outlinedButton}
+                      className={styles.filterOption}
+                      style={{ backgroundColor: backgroundFilters.includes(filterOption) ? '#F8F4FF' :  'transparent'}}
+                      disableRipple
+                      value={filterOption}
+                      key={filterOption}
+                    >
+                      {filterOption}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl focused={Boolean(audienceFilters.length)} className={styles.filter} variant="outlined">
+                <InputLabel shrink={false} className={styles.filterLabel}>
+                {!Boolean(audienceFilters.length) && "Audience"}
+                </InputLabel>
+                <Select
+                  className={styles.filterDropDown}
+                  multiple
+                  value={audienceFilters}
+                  onChange={handleAudienceChange}
+                  renderValue={(value) => (
+                    <InputLabel classes={{ root: styles.selectedLabel }}>
+                      Audience
+                    </InputLabel>
+                  )}
+                  MenuProps={{
+                    variant: 'menu',
+                    anchorOrigin: {
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    },
+                    getContentAnchorEl: null,
+                  }}
+                >
+                  {audienceTypes.map((filterOption: string) => (
+                    <MenuItem
+                      classes={{
+                        selected: styles.selectedFilter,
+                        root: styles.filterOption,
+                      }}
+                      component={outlinedButton}
+                      disableRipple
+                      style={{ backgroundColor: audienceFilters.includes(filterOption) ? '#F8F4FF' :  'transparent'}}
+                      value={filterOption}
+                      key={filterOption}
+                    >
+                      {filterOption}
+                    </MenuItem>
+                  ))}
+>>>>>>> feat: front end filters
                 </Select>
               </FormControl>
             </div>
 
             <div className={styles.cards}>
+<<<<<<< HEAD
               {orgs && orgs.length !== 0 ? (
+=======
+              {orgs.length !== 0 ? (
+>>>>>>> feat: front end filters
                 orgs.map((org) => (
                   <Card className={styles.card} key={org.id}>
                     <CardActionArea
@@ -136,6 +336,7 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
   );
 };
 
+<<<<<<< HEAD
 export default Results;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
@@ -182,5 +383,33 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         destination: '/',
       },
     };
+=======
+export default Home;
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  try {
+    const resp = await prisma.organization.findMany({
+      where: { active: true },
+      orderBy: {
+        name: 'asc',
+      },
+      select: {
+        id: true,
+        name: true,
+        organizationType: true,
+        workType: true,
+        lat: true,
+        long: true,
+      },
+    });
+    const orgs = JSON.parse(JSON.stringify(resp)) as PublicOrganization[];
+    return {
+      props: {
+        orgs,
+      },
+    };
+  } catch (err) {
+    return { props: { errors: err.message } };
+>>>>>>> feat: front end filters
   }
 };

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -45,6 +45,51 @@
   display: flex;
   flex-direction: row;
   padding: 10px;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+
+.filter {
+  min-width: 130px;
+}
+
+.filterDropDown {
+  border-radius: 35px;
+  width: 110px;
+  height: 35px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.filterOption {
+  font-style: normal;
+  font-size: 13px;
+  color: #423e45;
+  border-radius: 15px;
+  margin: 10px;
+  justify-content: center;
+  background-color: #ebebeb;
+}
+
+.filterLabel {
+  font-style: normal;
+  font-size: 13px;
+}
+
+.selectedLabel {
+  font-style: normal;
+  font-size: 13px;
+  margin-top: 4px;
+  color: #9056ef;
+}
+
+.selectedFilter {
+  font-style: normal;
+  font-size: 13px;
+  color: #9056ef;
+  border-radius: 15px;
+  margin: 10px;
+  justify-content: center;
 }
 
 .textField {

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -45,55 +45,6 @@
   display: flex;
   flex-direction: row;
   padding: 10px;
-  flex-wrap: wrap;
-  justify-content: space-around;
-}
-
-.filter {
-  min-width: 130px;
-}
-
-.filterDropDown {
-  border-radius: 35px;
-  width: 110px;
-  height: 25px;
-  margin-top: 13px;
-}
-
-.filterOption {
-  font-style: normal;
-  font-size: 13px;
-  color: #908D93;
-  border-radius: 18px;
-  border: 1px solid #908D93;
-  margin: 10px;
-  justify-content: center;
-  text-transform: none;
-  height: 25px;
-}
-
-.filterLabel {
-  font-style: normal;
-  font-size: 13px;
-}
-
-.selectedLabel {
-  font-style: normal;
-  font-size: 13px;
-  margin-top: 4px;
-  color: #9056ef;
-}
-
-.selectedFilter {
-  font-style: normal;
-  font-size: 13px;
-  color: #423E45;
-  border-radius: 18px;
-  border: 1px solid #423E45;
-  margin: 10px;
-  justify-content: center;
-  text-transform: none;
-  background: #F8F4FF;
 }
 
 .textField {

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -56,19 +56,20 @@
 .filterDropDown {
   border-radius: 35px;
   width: 110px;
-  height: 35px;
-  margin-top: 8px;
-  margin-bottom: 8px;
+  height: 25px;
+  margin-top: 13px;
 }
 
 .filterOption {
   font-style: normal;
   font-size: 13px;
-  color: #423e45;
-  border-radius: 15px;
+  color: #908D93;
+  border-radius: 18px;
+  border: 1px solid #908D93;
   margin: 10px;
   justify-content: center;
-  background-color: #ebebeb;
+  text-transform: none;
+  height: 25px;
 }
 
 .filterLabel {
@@ -86,10 +87,13 @@
 .selectedFilter {
   font-style: normal;
   font-size: 13px;
-  color: #9056ef;
-  border-radius: 15px;
+  color: #423E45;
+  border-radius: 18px;
+  border: 1px solid #423E45;
   margin: 10px;
   justify-content: center;
+  text-transform: none;
+  background: #F8F4FF;
 }
 
 .textField {

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -28,3 +28,12 @@
 .footer {
   height: 20px;
 }
+
+.searchbar {
+  width: 60%;
+}
+
+.searchField {
+  border: 1px solid rgb(182, 182, 182);
+  border-radius: 15px;
+}

--- a/styles/Results.module.css
+++ b/styles/Results.module.css
@@ -123,6 +123,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  align-items: baseline;
 }
 
 .filter {
@@ -230,4 +231,15 @@
   justify-content: center;
   text-transform: none;
   background: #f8f4ff;
+}
+
+.applyButton {
+  font-style: normal;
+  font-size: 13px;
+  border-radius: 18px;
+  border: 1px solid #908d93;
+  margin: 10px;
+  justify-content: bottom;
+  text-transform: none;
+  height: 25px;
 }

--- a/styles/Results.module.css
+++ b/styles/Results.module.css
@@ -151,12 +151,12 @@
 .leftCol {
   display: flex;
   flex-direction: column;
-  width: 33%;
+  width: 35%;
 }
 
 .rightCol {
   display: flex;
-  width: 66%;
+  width: 65%;
   border-width: 1px;
   border-style: solid;
   border-radius: 5px;
@@ -173,4 +173,61 @@
   margin: 8px;
   flex-basis: 45%;
   text-align: left;
+}
+
+.filter {
+  min-width: 130px;
+  margin: 8px;
+}
+
+.filterDropDown {
+  border-radius: 35px;
+  width: 120px;
+  height: 25px;
+  margin-top: 13px;
+}
+
+.filterDropDownActive {
+  border-radius: 35px;
+  width: 120px;
+  height: 25px;
+  margin-top: 13px;
+  background-color: #f8f4ff;
+  border-color: #d23245;
+}
+
+.filterOption {
+  font-style: normal;
+  font-size: 13px;
+  color: #908d93;
+  border-radius: 18px;
+  border: 1px solid #908d93;
+  margin: 10px;
+  justify-content: center;
+  text-transform: none;
+  height: 25px;
+}
+
+.filterLabel {
+  font-style: normal;
+  font-size: 13px;
+}
+
+.selectedLabel {
+  font-style: normal;
+  font-size: 13px;
+  margin-top: 4px;
+  color: #423e45;
+}
+
+.selectedFilter {
+  font-style: normal;
+  font-size: 13px;
+  color: #423e45;
+  border-radius: 18px;
+  border: 1px solid #423e45;
+  margin: 10px;
+  justify-content: center;
+  text-transform: none;
+  background: #f8f4ff;
 }


### PR DESCRIPTION
## Description
- Added in front end feature to allow users to select specific identities, backgrounds, and audiences
- Mostly followed style from Figma designs
- Some code could be cleaned up, but can be fixed through another iteration
- added in useStates to keep track of which filters are selected and to be used with Bryanna's code to filter orgs/events.

## Related PRs

Will integrate with Bryanna's backend filtering PR once merged.

## Screenshots

![Screen Shot 2021-04-14 at 9 19 51 PM](https://user-images.githubusercontent.com/28970991/114814341-d9baf500-9d68-11eb-913d-d07a95b98562.png)




CC: @claalmve
