### PR TITLE
Fix homepage cover image repeating

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -8,7 +8,9 @@
   height: calc(100vh - 115px);
   border-radius: 25px;
   padding: 80px;
-  background-image: url('public/homepage.png');
+  background-image: url('/homepage.png');
+  background-repeat: no-repeat;
+  background-size: cover;
 }
 
 .leftCol {


### PR DESCRIPTION
Fix cover image of homepage that was repeating on overflow. Changed to simply cover/fill the container so there is no repeating image.

## Screenshots

### Previous
![image](https://user-images.githubusercontent.com/9738398/114975578-56b59f80-9e39-11eb-8fd0-6e27521bb874.png)

### Fix
![image](https://user-images.githubusercontent.com/9738398/114975613-62a16180-9e39-11eb-917e-e14ccc19570d.png)


CC: @claalmve
