### PR TITLE
fix: remove response for signin which is void

### DIFF
--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -34,12 +34,11 @@ const UserSignIn: React.FC = () => {
   ): Promise<void> => {
     try {
       // Sign in with credentials
-      const res = await signIn('credentials', {
+      await signIn('credentials', {
         email: values.email,
         password: values.password,
         redirect: false,
       });
-      setErrorBanner(res.error ?? '');
     } catch (err) {
       console.log(err);
     } finally {

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -53,12 +53,11 @@ const UserSignUp: React.FC = () => {
       }
 
       // Sign in user
-      const signInRes = await signIn('credentials', {
+      await signIn('credentials', {
         email: values.email,
         password: values.password,
         redirect: false,
       });
-      setErrorBanner(signInRes.error ?? '');
     } catch (err) {
       if (err.errorCode === 'DUP_EMAIL') {
         setErrorBanner(


### PR DESCRIPTION
Removed response for signin await which was being used for error message, but it returns void.

## Related PRs

_Optional - any related PRs you're waiting on, or PRs that will conflict, etc_

## Migrations

_Optional - if you added anything to the database through migration(s)_

## Screenshots

_Required for visual changes_

CC: @claalmve
