### PR TITLE
feat: made img carousel

### DIFF
--- a/components/organization/ImgCarousel/ImgCarousel.module.css
+++ b/components/organization/ImgCarousel/ImgCarousel.module.css
@@ -1,52 +1,53 @@
 .sideTab {
-    width: 100%;
-    height: 100px;
-    background-color: #ECEAEE;
-    border-radius: 18px;
-    display: flex;
-    margin-bottom: 15px;
+  width: 100%;
+  height: 100px;
+  background-color: #eceaee;
+  border-radius: 18px;
+  display: flex;
+  margin-bottom: 15px;
 }
 
 .tabs {
-    width: 18%;
-    display: flex;
-    margin:0;
-    height: 100%;
-    justify-content: center;
-    align-items: center;
+  width: 18%;
+  display: flex;
+  margin: 0;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  /* overflow-y: scroll; */
 }
 
 .tabPanel {
-    display: flex;
-    width: 80%;
-    height: 100%;
-    margin-top: -47px;
-    margin-left: auto;
+  display: flex;
+  width: 80%;
+  height: 100%;
+  margin-top: -47px;
+  margin-left: auto;
   margin-right: auto;
   object-fit: cover;
-    border-radius: 18px;
+  border-radius: 18px;
 }
 
 .tabImg {
-    display: flex;
-    width: 100%;
-    height: 330px;
-    border-radius: 18px;
-    margin-left: auto;
+  display: flex;
+  width: 100%;
+  height: 330px;
+  border-radius: 18px;
+  margin-left: auto;
   margin-right: auto;
   object-fit: cover;
 }
 
 .img {
-    object-fit: cover;
+  object-fit: cover;
 }
 
 .root {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: row;
-    width: 75%;
-    height: 330px;
-    margin-bottom: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  width: 75%;
+  height: 330px;
+  margin-bottom: 50px;
 }

--- a/components/organization/ImgCarousel/ImgCarousel.module.css
+++ b/components/organization/ImgCarousel/ImgCarousel.module.css
@@ -1,0 +1,52 @@
+.sideTab {
+    width: 100%;
+    height: 100px;
+    background-color: #ECEAEE;
+    border-radius: 18px;
+    display: flex;
+    margin-bottom: 15px;
+}
+
+.tabs {
+    width: 18%;
+    display: flex;
+    margin:0;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+}
+
+.tabPanel {
+    display: flex;
+    width: 80%;
+    height: 100%;
+    margin-top: -47px;
+    margin-left: auto;
+  margin-right: auto;
+  object-fit: cover;
+    border-radius: 18px;
+}
+
+.tabImg {
+    display: flex;
+    width: 100%;
+    height: 330px;
+    border-radius: 18px;
+    margin-left: auto;
+  margin-right: auto;
+  object-fit: cover;
+}
+
+.img {
+    object-fit: cover;
+}
+
+.root {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: row;
+    width: 75%;
+    height: 330px;
+    margin-bottom: 50px;
+}

--- a/components/organization/ImgCarousel/index.tsx
+++ b/components/organization/ImgCarousel/index.tsx
@@ -1,14 +1,9 @@
-// eslint-disable-next-line no-use-before-define
-import React from 'react';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
+import { Tab, Tabs, Typography, Box } from '@material-ui/core';
+import { useState } from 'react';
 import styles from './ImgCarousel.module.css';
 
 interface TabPanelProps {
-  // eslint-disable-next-line react/require-default-props
-  children?: React.ReactNode;
+  children: React.ReactNode;
   index: any;
   value: any;
 }
@@ -45,32 +40,25 @@ type ImgProps = {
 };
 
 const ImgCarousel: React.FC<ImgProps> = ({ images }) => {
-  const [value, setValue] = React.useState(0);
-
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
-    setValue(newValue);
-  };
+  const [imgIndex, setImgIndex] = useState(0);
 
   return (
     <div className={styles.root}>
       <div className={styles.tabPanel}>
-        <TabPanel value={value} index={0}>
-          <img className={styles.tabImg} src={images[0]} alt="0" />
-        </TabPanel>
-        <TabPanel value={value} index={1}>
-          <img className={styles.tabImg} src={images[1]} alt="1" />
-        </TabPanel>
-        <TabPanel value={value} index={2}>
-          <img className={styles.tabImg} src={images[2]} alt="2" />
-        </TabPanel>
+        {images && images.length
+          ? images.map((img, idx) => (
+              <TabPanel value={imgIndex} index={idx}>
+                <img className={styles.tabImg} src={img} alt={idx.toString()} />
+              </TabPanel>
+            ))
+          : null}
       </div>
       <Tabs
         orientation="vertical"
-        variant="standard"
+        variant="scrollable"
         selectionFollowsFocus={false}
-        value={value}
-        onChange={handleChange}
+        value={imgIndex}
+        onChange={(e, newVal) => setImgIndex(newVal)}
         aria-label="Vertical tabs"
         className={styles.tabs}
         TabIndicatorProps={{
@@ -79,21 +67,15 @@ const ImgCarousel: React.FC<ImgProps> = ({ images }) => {
           },
         }}
       >
-        <Tab
-          className={styles.sideTab}
-          icon={<img alt="0" src={images[0]} />}
-          {...a11yProps(0)}
-        />
-        <Tab
-          className={styles.sideTab}
-          icon={<img alt="1" src={images[1]} />}
-          {...a11yProps(1)}
-        />
-        <Tab
-          className={styles.sideTab}
-          icon={<img alt="2" src={images[2]} />}
-          {...a11yProps(2)}
-        />
+        {images && images.length
+          ? images.map((img, idx) => (
+              <Tab
+                className={styles.sideTab}
+                icon={<img alt={idx.toString()} src={img} />}
+                {...a11yProps(idx)}
+              />
+            ))
+          : null}
       </Tabs>
     </div>
   );

--- a/components/organization/ImgCarousel/index.tsx
+++ b/components/organization/ImgCarousel/index.tsx
@@ -1,0 +1,102 @@
+// eslint-disable-next-line no-use-before-define
+import React from 'react';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import styles from './ImgCarousel.module.css';
+
+interface TabPanelProps {
+  // eslint-disable-next-line react/require-default-props
+  children?: React.ReactNode;
+  index: any;
+  value: any;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`vertical-tabpanel-${index}`}
+      aria-labelledby={`vertical-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box p={3}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function a11yProps(index: any) {
+  return {
+    id: `vertical-tab-${index}`,
+    'aria-controls': `vertical-tabpanel-${index}`,
+  };
+}
+
+type ImgProps = {
+  images: Array<string>;
+};
+
+const ImgCarousel: React.FC<ImgProps> = ({ images }) => {
+  const [value, setValue] = React.useState(0);
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.tabPanel}>
+        <TabPanel value={value} index={0}>
+          <img className={styles.tabImg} src={images[0]} alt="0" />
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+          <img className={styles.tabImg} src={images[1]} alt="1" />
+        </TabPanel>
+        <TabPanel value={value} index={2}>
+          <img className={styles.tabImg} src={images[2]} alt="2" />
+        </TabPanel>
+      </div>
+      <Tabs
+        orientation="vertical"
+        variant="standard"
+        selectionFollowsFocus={false}
+        value={value}
+        onChange={handleChange}
+        aria-label="Vertical tabs"
+        className={styles.tabs}
+        TabIndicatorProps={{
+          style: {
+            display: 'none',
+          },
+        }}
+      >
+        <Tab
+          className={styles.sideTab}
+          icon={<img alt="0" src={images[0]} />}
+          {...a11yProps(0)}
+        />
+        <Tab
+          className={styles.sideTab}
+          icon={<img alt="1" src={images[1]} />}
+          {...a11yProps(1)}
+        />
+        <Tab
+          className={styles.sideTab}
+          icon={<img alt="2" src={images[2]} />}
+          {...a11yProps(2)}
+        />
+      </Tabs>
+    </div>
+  );
+};
+
+export default ImgCarousel;

--- a/pages/orgs/[id].tsx
+++ b/pages/orgs/[id].tsx
@@ -23,6 +23,7 @@ import {
   AgeDemographic,
   Organization,
   Prisma,
+  OrganizationEvent,
 } from '@prisma/client';
 import Layout from 'components/Layout';
 import Tab from 'components/Tab';
@@ -40,6 +41,7 @@ import useSession from 'utils/useSession';
 import Toast from 'components/Toast';
 import EventCard from 'components/organization/EventCard';
 import Project from 'components/organization/Project';
+import ImgCarousel from 'components/organization/ImgCarousel';
 import styles from '../../styles/Organization.module.css';
 
 type Props = {
@@ -67,14 +69,21 @@ const OrgProfile: React.FunctionComponent<Props> = ({
   const [editState, setEditState] = useState<0 | 1>(0); // 0 == read, 1 == edit
   const [errorBanner, setErrorBanner] = useState('');
   const [org, setOrg] = useState(orgProp);
-  const eventsList = org?.organizationEvents?.map((event) => {
-    return (
-      <div className={styles.event}>
-        <EventCard event={event} />
-      </div>
-    );
-  });
+  const eventsList = org?.organizationEvents?.map(
+    (event: OrganizationEvent) => {
+      return (
+        <div className={styles.event}>
+          <EventCard event={event} />
+        </div>
+      );
+    }
+  );
   const [session, sessionLoading] = useSession();
+  const images = [
+    'https://1mktxg24rspz19foqjixu9rl-wpengine.netdna-ssl.com/wp-content/uploads/2020/01/eia-berkeley-Cover.png',
+    'public/logo2.png',
+    'public/sampleCover.png',
+  ];
 
   const cleanVals = (o: EditForm): EditForm => ({
     name: (o && o.name) ?? '',
@@ -481,10 +490,7 @@ const OrgProfile: React.FunctionComponent<Props> = ({
     <Layout title={`${org && org.name} Profile`}>
       <div className={styles.orgMargins}>
         <div className={styles.orgImages}>
-          <img
-            src="https://1mktxg24rspz19foqjixu9rl-wpengine.netdna-ssl.com/wp-content/uploads/2020/01/eia-berkeley-Cover.png"
-            alt="Organization"
-          />
+          <ImgCarousel images={images} />
         </div>
         <form onSubmit={formik.handleSubmit}>
           {errorBanner ? (

--- a/pages/orgs/[id].tsx
+++ b/pages/orgs/[id].tsx
@@ -81,8 +81,9 @@ const OrgProfile: React.FunctionComponent<Props> = ({
   const [session, sessionLoading] = useSession();
   const images = [
     'https://1mktxg24rspz19foqjixu9rl-wpengine.netdna-ssl.com/wp-content/uploads/2020/01/eia-berkeley-Cover.png',
-    'public/logo2.png',
-    'public/sampleCover.png',
+    '/logo1.png',
+    '/homepage.png',
+    '/logo1.png',
   ];
 
   const cleanVals = (o: EditForm): EditForm => ({

--- a/pages/orgs/results.tsx
+++ b/pages/orgs/results.tsx
@@ -46,12 +46,12 @@ const Results: React.FC<ResultsProps> = ({ orgs }) => {
   const [searchVal, setSearchVal] = useState(orgName as string | undefined);
   const [demographicFilters, setDemographicFilters] = useState<
     LgbtqDemographic[]
-  >(filtersConverter(orientation));
+  >(filtersConverter(orientation) ?? []);
   const [backgroundFilters, setBackgroundFilters] = useState<RaceDemographic[]>(
-    filtersConverter(ethnicity)
+    filtersConverter(ethnicity) ?? []
   );
   const [audienceFilters, setAudienceFilters] = useState<AgeDemographic[]>(
-    filtersConverter(ages)
+    filtersConverter(ages) ?? []
   );
 
   const handleDemographicChange = (


### PR DESCRIPTION
Used Material-UI Tabs to make manual img carousel.

## Screenshots

<img width="1680" alt="Screen Shot 2021-05-03 at 9 51 47 AM" src="https://user-images.githubusercontent.com/60284767/116906492-2e79bf00-abf5-11eb-84cb-e10b001fbd77.png">

(only reason why this image isn't popping up is because I couldn't figure out how to present an image onto here using the whole src prop but it works)
<img width="1680" alt="Screen Shot 2021-05-03 at 9 52 43 AM" src="https://user-images.githubusercontent.com/60284767/116906582-4fdaab00-abf5-11eb-8871-884d42ca4a23.png">

(same thing here)
<img width="1680" alt="Screen Shot 2021-05-03 at 9 52 57 AM" src="https://user-images.githubusercontent.com/60284767/116906612-58cb7c80-abf5-11eb-8d2d-70ffb90b0076.png">


CC: @claalmve @elixawu 
