### PR TITLE
style: fixed dropdown border and shadow

### DIFF
--- a/components/results/Filters/Filters.module.css
+++ b/components/results/Filters/Filters.module.css
@@ -65,3 +65,8 @@
   text-transform: none;
   height: 25px;
 }
+
+.selectMenuOver {
+  box-shadow: -2px 4px 23px rgba(0, 0, 0, 0.0685);
+  border-radius: 18px;
+}

--- a/components/results/Filters/index.tsx
+++ b/components/results/Filters/index.tsx
@@ -75,6 +75,9 @@ const Filters: React.FunctionComponent<FiltersProps> = ({
               vertical: 'bottom',
               horizontal: 'left',
             },
+            classes: {
+              paper: styles.selectMenuOver,
+            },
             getContentAnchorEl: null,
           }}
         >
@@ -129,6 +132,9 @@ const Filters: React.FunctionComponent<FiltersProps> = ({
             anchorOrigin: {
               vertical: 'bottom',
               horizontal: 'left',
+            },
+            classes: {
+              paper: styles.selectMenuOver,
             },
             getContentAnchorEl: null,
           }}
@@ -185,6 +191,9 @@ const Filters: React.FunctionComponent<FiltersProps> = ({
             anchorOrigin: {
               vertical: 'bottom',
               horizontal: 'left',
+            },
+            classes: {
+              paper: styles.selectMenuOver,
             },
             getContentAnchorEl: null,
           }}


### PR DESCRIPTION
Fixed the filter dropdown border and shadow to look more like the Figma design.

NOTE:
- branched off of main
- should merge pretty well with the bryanna/map-frontend branch
     - (sorry it wasn't branched off of that branch aaaaaa ;-; trying to speed run)

## Screenshots

<img width="258" alt="Screen Shot 2021-05-03 at 10 27 33 AM" src="https://user-images.githubusercontent.com/60284767/116910241-2ec88900-abfa-11eb-95df-0a182c36dbc7.png">


CC: @claalmve @elixawu 
