### PR TITLE
fix: fixed results page filters front end

### DIFF
--- a/components/results/Filters/Filters.module.css
+++ b/components/results/Filters/Filters.module.css
@@ -16,7 +16,6 @@
   height: 25px;
   margin-top: 13px;
   background-color: #f8f4ff;
-  border-color: #d23245;
 }
 
 .filterOption {

--- a/components/results/Filters/index.tsx
+++ b/components/results/Filters/index.tsx
@@ -89,11 +89,9 @@ const Filters: React.FunctionComponent<FiltersProps> = ({
                   root: styles.filterOption,
                 }}
                 style={{
-                  backgroundColor: demographicFilters.includes(
-                    LgbtqDemographicLabels[filterOption] as LgbtqDemographic
-                  )
+                  backgroundColor: demographicFilters.includes(filterOption)
                     ? '#F8F4FF'
-                    : 'transparent',
+                    : 'white',
                 }}
                 component={outlinedButton}
                 disableRipple
@@ -147,13 +145,10 @@ const Filters: React.FunctionComponent<FiltersProps> = ({
                   root: styles.filterOption,
                 }}
                 component={outlinedButton}
-                className={styles.filterOption}
                 style={{
-                  backgroundColor: backgroundFilters.includes(
-                    RaceDemographicLabels[filterOption] as RaceDemographic
-                  )
+                  backgroundColor: backgroundFilters.includes(filterOption)
                     ? '#F8F4FF'
-                    : 'transparent',
+                    : 'white',
                 }}
                 disableRipple
                 value={filterOption}
@@ -208,11 +203,9 @@ const Filters: React.FunctionComponent<FiltersProps> = ({
                 component={outlinedButton}
                 disableRipple
                 style={{
-                  backgroundColor: audienceFilters.includes(
-                    AgeDemographicLabels[filterOption] as AgeDemographic
-                  )
+                  backgroundColor: audienceFilters.includes(filterOption)
                     ? '#F8F4FF'
-                    : 'transparent',
+                    : 'white',
                 }}
                 value={filterOption}
               >


### PR DESCRIPTION
Fixed the appearance of filters/chips when selected on the results page.
Fixed how background color was being selected in the MenuItem components.

## Screenshots

![Screen Shot 2021-05-05 at 5 19 15 PM](https://user-images.githubusercontent.com/28970991/117225127-700d9400-adc6-11eb-99bb-9c892d6a3ee1.png)


CC: @claalmve
